### PR TITLE
issue-1: Search list not persistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. This change
 ### Unreleased Added
 
 - Dockerfile for building the service in a container.
+- Persistent searches ([issue-1](https://github.com/wdhowe/lemme-know-bot/issues/1))
 
 ## 0.1.0 - 2020-11-23
 

--- a/src/lemme_know_bot/config.clj
+++ b/src/lemme_know_bot/config.clj
@@ -1,11 +1,36 @@
 (ns lemme-know-bot.config
   (:gen-class)
-  (:require [environ.core :as environ]))
+  (:require [clojure.edn :as edn]
+            [environ.core :as environ]
+            [clojure.java.io :as io]
+            [taoensso.timbre :as log]))
 
 (def config
   {:timeout (or (environ/env :lkb-timeout) 10) ; timeout in seconds to wait for long polling
    :sleep (or (environ/env :lkb-sleep) 10000); sleep in milliseconds between polls
-   })
+   :searches (or (environ/env :lkb-searches) "/tmp/lemme-know-bot-searches.edn")})
 
 (comment
   (println "config is:" config))
+
+(defn load-edn
+  "Load edn files from an io/reader `source` (filename or io/resource).
+   Orig fn: https://clojuredocs.org/clojure.edn/read#example-5a68f384e4b09621d9f53a79"
+  [source]
+  (try
+    (with-open [r (io/reader source)]
+      (edn/read (java.io.PushbackReader. r)))
+
+    (catch java.io.IOException e
+      (log/errorf "couldn't open '%s': %s" source (.getMessage e)))
+    (catch RuntimeException e
+      (log/errorf "error parsing edn file '%s': %s" source (.getMessage e)))))
+
+(defn save-file
+  "Save a data structure to a file."
+  [content dest]
+  (try
+    (spit dest content)
+
+    (catch java.io.IOException e
+      (log/errorf "couldn't write to '%s': %s" dest (.getMessage e)))))

--- a/src/lemme_know_bot/notify.clj
+++ b/src/lemme_know_bot/notify.clj
@@ -1,8 +1,30 @@
 (ns lemme-know-bot.notify
   "Functions to add, list, remove, track the notify search list."
-  (:gen-class))
+  (:gen-class)
+  (:require [taoensso.timbre :as log]))
 
 (defonce searches (atom []))
+
+(defprotocol search-data
+  "Only load supported data types."
+  (load-searches! [content]
+    "Load a searches data structure at once, merging content with an existing."))
+
+(extend-protocol search-data
+  clojure.lang.PersistentVector
+  (load-searches!
+    [content]
+    (swap! searches into content))
+  Object
+  (load-searches!
+    [content]
+    (log/warn "not loading searches. data is not a supported type.")))
+
+(comment
+  (load-searches! [{:user "user1", :text "my search1"}])
+  (load-searches! [{:user "user2", :text "my search2"}])
+  (load-searches! {:user "user1" :text "invalid"})
+  (load-searches! "invalid"))
 
 (defn add-search!
   "Add a search to the searches atom vector."

--- a/test/lemme_know_bot/notify_test.clj
+++ b/test/lemme_know_bot/notify_test.clj
@@ -1,5 +1,5 @@
 (ns lemme-know-bot.notify-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [are deftest is testing]]
             [lemme-know-bot.notify :as notify]))
 
 (deftest searches-test
@@ -27,3 +27,15 @@
 
       ;; count after removing another search
       (is (= 2 (count rm-search))))))
+
+(deftest load-searches!-test
+  (testing "Testing load-searches! with different data structures."
+    (are [func result] (= func result)
+
+      ;; count is 4 due to previous test's manipulation of the atom
+      (count (notify/load-searches! [{:user "user1", :text "hello"}
+                                     {:user "user1", :text "hi there"}])) 4
+
+      (count (notify/load-searches! {:user "user1", :text "invalid"})) 0
+
+      (count (notify/load-searches! "invalid")) 0)))


### PR DESCRIPTION
Support for a persistent searches data structure.

- New functions for loading an edn file and saving any generic file.
- New load-searches! function that merges two edn data structures.
- New function edn->searches that loads the external edn file and then merges with load-searches! if the edn file has content.
- Save the in memory edn file to disk during shutdown hook.

Closes #1 