### PR TITLE
issue-4: Http exceptions not caught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. This change
 
 - Dockerfile for building the service in a container.
 - Persistent searches ([issue-1](https://github.com/wdhowe/lemme-know-bot/issues/1))
+- Catch HTTP exceptions ([issue-4](https://github.com/wdhowe/lemme-know-bot/issues/4))
 
 ## 0.1.0 - 2020-11-23
 

--- a/src/lemme_know_bot/handlers.clj
+++ b/src/lemme_know_bot/handlers.clj
@@ -11,7 +11,11 @@
 (defn send-msg
   "Send a message to the chat."
   [bot chat-id text]
-  (tbot/send-message bot chat-id text))
+  (try
+    (tbot/send-message bot chat-id text)
+
+    (catch Exception e
+      (log/error "tbot/send-message exception:" e))))
 
 (defn help
   "Send info about this bot and available commands."


### PR DESCRIPTION
Catch exceptions from the tbot/send-message function and log the error.

Closes #4 