### PR TITLE
issue-2: Search list shared across chats - make per chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
-- Nothing yet.
+- Search lists are now chat+username specific (no longer shared across chats) ([issue-2](https://github.com/wdhowe/lemme-know-bot/issues/2))
 
 ## [0.2.1] - 2020-11-26
 

--- a/test/lemme_know_bot/notify_test.clj
+++ b/test/lemme_know_bot/notify_test.clj
@@ -2,40 +2,49 @@
   (:require [clojure.test :refer [are deftest is testing]]
             [lemme-know-bot.notify :as notify]))
 
-(deftest searches-test
-  (testing "Testing searches atom."
-    (let [one-search (notify/add-search! "yoda" "hello")
-          two-searches (notify/add-search! "yoda" "hi there")
-          three-searches (notify/add-search! "luke" "ahoy")
-          dupe-search (notify/add-search! "luke" "ahoy")
-          clean-search (notify/clean-searches!)
-          rm-search (notify/remove-search! "yoda" "hi there")]
+(deftest add-search!-test
+  (testing "Test adding searches."
+    (let [;test chat-id add by integer
+          one-search (notify/add-search! 123 "yoda" "hello")
+          ;add the rest of the chat-ids by string
+          two-searches (notify/add-search! "123" "yoda" "hi there")
+          three-searches (notify/add-search! "123" "luke" "ahoy")
+          dupe-search (notify/add-search! "123" "luke" "ahoy")]
 
-      ;; check text after adding 1 and 2 searches
+      ;; check text after adding 2 searches
       (is (= "hello" (:text (first one-search))))
       (is (= "hi there" (:text (second two-searches))))
 
-      ;; check total and user specific count after 3rd search
+      ;; count after 3rd search
       (is (= 3 (count three-searches)))
-      (is (= 1 (count (notify/list-searches "luke"))))
 
       ;; count after a duplicate
-      (is (= 4 (count dupe-search)))
+      (is (= 4 (count dupe-search))))))
 
-      ;; count after removing duplicates
-      (is (= 3 (count clean-search)))
+(deftest clean-searches!-test
+  (testing "Test cleaning up duplicates."
+    (let [clean-search (notify/clean-searches!)]
+    ;; count after removing duplicates
+      (is (= 3 (count clean-search))))))
 
-      ;; count after removing another search
-      (is (= 2 (count rm-search))))))
+(deftest list-searches-test
+  (testing "Test listing searches."
+    (is (= 1 (count (notify/list-searches "123" "luke"))))))
 
 (deftest load-searches!-test
   (testing "Testing load-searches! with different data structures."
     (are [func result] (= func result)
 
-      ;; count is 4 due to previous test's manipulation of the atom
-      (count (notify/load-searches! [{:user "user1", :text "hello"}
-                                     {:user "user1", :text "hi there"}])) 4
+      ;; count is 5 due to previous test's manipulation of the atom
+      (count (notify/load-searches! [{:chat-id "123" :user "user1", :text "hello"}
+                                     {:chat-id "123" :user "user1", :text "hi there"}])) 5
 
       (count (notify/load-searches! {:user "user1", :text "invalid"})) 0
 
       (count (notify/load-searches! "invalid")) 0)))
+
+(deftest remove-search!-test
+  (testing "Test removing a search item."
+    (let [rm-search (notify/remove-search! "123" "yoda" "hi there")]
+      ;; count after removing another search
+      (is (= 4 (count rm-search))))))


### PR DESCRIPTION
- Added a chat-id key to the searches atom.
- Updated other functions that access that atom to account for the new chat-id field.
- Filter on chat-ids when searching for words/phrases.

Closes #2 