### PR TITLE
Dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+- Nothing yet.
+
+## [0.4.0] - 2021-07-24
+
+### 0.4.0 Changed
+
 - Protect get-updates from exiting the bot with any exceptions, log the error instead.
 - Send messages on a futures thread to continue processing.
+- Updated project dependency versions.
 
 ## [0.3.1] - 2020-11-29
 
@@ -40,7 +47,8 @@ All notable changes to this project will be documented in this file. This change
 
 ---
 
-[Unreleased]: https://github.com/wdhowe/lemme-know-bot/compare/0.3.1...HEAD
+[Unreleased]: https://github.com/wdhowe/lemme-know-bot/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/wdhowe/lemme-know-bot/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/wdhowe/lemme-know-bot/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/wdhowe/lemme-know-bot/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/wdhowe/lemme-know-bot/compare/0.2.0...0.2.1

--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ Using the lemme-know-bot code in your own project.
 
 To build the service JAR or use the Docker container instead, go to the next section.
 
-Leiningen/Boot Project file
+See the `lemme-know-bot` [Clojars page][clojars] for details on adding this library to projects for Leiningen, Boot, and CLI/deps.edn.
 
-```clojure
-[lemme-know-bot "0.3.1"]
-```
-
-### Include the Library
+### Require the Library
 
 In the REPL
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,6 @@ at <https://www.gnu.org/software/classpath/license.html>.
 [gh-actions]: https://github.com/wdhowe/lemme-know-bot/actions
 [cljdoc-badge]: https://cljdoc.org/badge/lemme-know-bot/lemme-know-bot
 [cljdoc-link]: https://cljdoc.org/d/lemme-know-bot/lemme-know-bot/CURRENT
-[clojure-v]: https://img.shields.io/badge/clojure-1.10.0-blue.svg
+[clojure-v]: https://img.shields.io/badge/clojure-1.10.3-blue.svg
 [clojars]: https://clojars.org/lemme-know-bot
 [clojars-badge]: https://img.shields.io/clojars/v/lemme-know-bot.svg

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,13 @@
-(defproject lemme-know-bot "0.3.1"
+(defproject lemme-know-bot "0.4.0"
   :description "A Telegram Bot that mentions you when the specified text in a chat matches."
   :url "https://github.com/wdhowe/lemme-know-bot"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[com.taoensso/timbre "5.1.0"]
+  :dependencies [[com.taoensso/timbre "5.1.2"]
                  [environ "1.2.0"]
-                 [org.clojure/clojure "1.10.1"]
-                 [telegrambot-lib "0.3.1"]]
+                 [org.clojure/clojure "1.10.3"]
+                 [telegrambot-lib "1.0.0"]
+                 [cheshire "5.10.1"]]
   :main ^:skip-aot lemme-know-bot.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}


### PR DESCRIPTION
- Dependency bumps for almost all libraries.
- New dependency on cheshire, due to telegrambot-lib 1.0.0 requiring a 'provide your preferred json library'.
- Eliminate version information from the README. Link to clojars instead.